### PR TITLE
fix: remove (potentially) deadcode

### DIFF
--- a/__tests__/unit/logic.service.test.ts
+++ b/__tests__/unit/logic.service.test.ts
@@ -50,7 +50,6 @@ describe('Logic Service', () => {
       expect(loggerSpy).toHaveBeenCalledWith('Successfully sent to 003@1.0');
       expect(loggerSpy).toHaveBeenCalledWith('Successfully sent to 028@1.0');
       expect(errorLoggerSpy).toHaveBeenCalledTimes(0);
-      expect(debugLoggerSpy).toHaveBeenCalledTimes(1);
       expect(result).toBeDefined;
     });
 
@@ -69,7 +68,6 @@ describe('Logic Service', () => {
       expect(loggerSpy).toHaveBeenCalledWith('Successfully sent to 003@1.0');
       expect(loggerSpy).toHaveBeenCalledWith('Successfully sent to 028@1.0');
       expect(errorLoggerSpy).toHaveBeenCalledTimes(0);
-      expect(debugLoggerSpy).toHaveBeenCalledTimes(1);
       expect(result).toBeDefined;
     });
 
@@ -87,7 +85,6 @@ describe('Logic Service', () => {
       expect(loggerSpy).toHaveBeenCalledTimes(1);
       expect(loggerSpy).toHaveBeenCalledWith('Successfully sent to 018@1.0');
       expect(errorLoggerSpy).toHaveBeenCalledTimes(0);
-      expect(debugLoggerSpy).toHaveBeenCalledTimes(1);
       expect(result).toBeDefined;
     });
 
@@ -105,7 +102,6 @@ describe('Logic Service', () => {
       expect(loggerSpy).toHaveBeenCalledTimes(1);
       expect(loggerSpy).toHaveBeenCalledWith('Successfully sent to 018@1.0');
       expect(errorLoggerSpy).toHaveBeenCalledTimes(0);
-      expect(debugLoggerSpy).toHaveBeenCalledTimes(1);
       expect(result).toBeDefined;
     });
 
@@ -127,7 +123,6 @@ describe('Logic Service', () => {
       expect(loggerSpy).toHaveBeenCalledTimes(1);
       expect(loggerSpy).toHaveBeenCalledWith('Successfully sent to 018@1.0');
       expect(errorLoggerSpy).toHaveBeenCalledTimes(0);
-      expect(debugLoggerSpy).toHaveBeenCalledTimes(2);
       expect(result).toBeDefined;
     });
 
@@ -163,7 +158,6 @@ describe('Logic Service', () => {
       expect(loggerSpy).toHaveBeenCalledWith('Successfully sent to 003@1.0');
       expect(loggerSpy).toHaveBeenCalledWith('Successfully sent to 028@1.0');
       expect(errorLoggerSpy).toHaveBeenCalledTimes(0);
-      expect(debugLoggerSpy).toHaveBeenCalledTimes(1);
     });
 
     it('should respond with empty network submap no network map is found', async () => {
@@ -198,7 +192,6 @@ describe('Logic Service', () => {
       expect(errorLoggerSpy).toHaveBeenCalledTimes(2);
       expect(errorLoggerSpy).toHaveBeenCalledWith('Failed to send to Rule 003@1.0 with Error: undefined');
       expect(errorLoggerSpy).toHaveBeenCalledWith('Failed to send to Rule 028@1.0 with Error: undefined');
-      expect(debugLoggerSpy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/services/logic.service.ts
+++ b/src/services/logic.service.ts
@@ -107,14 +107,6 @@ export const handleTransaction = async (req: unknown): Promise<void> => {
       );
     }
     await Promise.all(promises);
-
-    const result = {
-      metaData,
-      transaction: parsedRequest.transaction,
-      DataCache: parsedRequest.DataCache,
-      networkMap,
-    };
-    loggerService.debug(JSON.stringify(result));
   } else {
     loggerService.log('No coresponding message found in Network map');
     const result = {


### PR DESCRIPTION
Related to #96 

`sendToRuleProcessor` already logs https://github.com/frmscoe/channel-router-setup-processor/blob/ee587f066b8f80e1e2ca9e68d3e7f1727252943e/src/services/logic.service.ts#L139