### PR TITLE
fix: use passing node.js workflow without integration tests

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,32 +5,11 @@
 
 name: Node.js CI
 env:
-  NODE_ENV: 'dev'
-  STARTUP_TYPE: 'nats'
-  SERVER_URL: 'nats://localhost:4222'
-  ACK_POLICY: 'None'
-  PRODUCER_STREAM: 'temp-rule-sub'
-  CONSUMER_STREAM: 'event-director'
-  STREAM_SUBJECT:
-  APM_ACTIVE: false
-  APM_LOGGING: false
-  FUNCTION_NAME: ${{ github.event.repository.name }}
-  REDIS_DB: 0
-  REDIS_AUTH:
-  REDIS_SERVERS: '[{"host":"127.0.0.1", "port":6379}]'
-  REDIS_IS_CLUSTER: false
-  DATABASE_URL: 'http://localhost:8529/'
-  DATABASE_USER: 'root'
-  DATABASE_PASSWORD:
-  DATABASE_NAME: 'networkmap'
-  REPO_NAME: 'performance-benchmark'
-  GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-  GH_RW_TOKEN: '${{ secrets.GH_WRITE_TOKEN }}'
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   NPM_SCOPE: "@frmscoe"
   NPM_REGISTRY: "https://npm.pkg.github.com/"
-  ENV_NEWMAN: https://raw.githubusercontent.com/frmscoe/postman/indexes/environments/Ekuta-LOCAL.postman_environment.json
-  THRESHOLD: 5
-  ITERATION_COUNT: 1000
+  NODE_ENV: 'test'
+  STARTUP_TYPE: 'nats'
 
 on:
   push:


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Unify the node.js.yml workflow across repos by removing integration tests from the run steps.

## Why are we doing this?
The node.js.yaml workflow in this repo was causing failures which blocked the 2.0.0 release.

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done
