### PR TITLE
fix: cache ignore tenantId

### DIFF
--- a/__tests__/unit/logic.service.test.ts
+++ b/__tests__/unit/logic.service.test.ts
@@ -75,8 +75,6 @@ describe('Logic Service', () => {
       const result = debugLog;
 
       expect(loggerSpy).toHaveBeenCalledWith('Loaded and cached network map for tenant: acme');
-      expect(loggerSpy).toHaveBeenCalledWith('Successfully sent to 003@1.0');
-      expect(loggerSpy).toHaveBeenCalledWith('Successfully sent to 028@1.0');
       expect(errorLoggerSpy).toHaveBeenCalledTimes(0);
       expect(result).toBeDefined();
     });
@@ -93,8 +91,6 @@ describe('Logic Service', () => {
       const result = debugLog;
 
       expect(loggerSpy).toHaveBeenCalledWith('Loaded and cached network map for tenant: acme');
-      expect(loggerSpy).toHaveBeenCalledWith('Successfully sent to 003@1.0');
-      expect(loggerSpy).toHaveBeenCalledWith('Successfully sent to 028@1.0');
       expect(errorLoggerSpy).toHaveBeenCalledTimes(0);
       expect(result).toBeDefined();
     });
@@ -111,7 +107,6 @@ describe('Logic Service', () => {
       const result = debugLog;
 
       expect(loggerSpy).toHaveBeenCalledWith('Loaded and cached network map for tenant: acme');
-      expect(loggerSpy).toHaveBeenCalledWith('Successfully sent to 018@1.0');
       expect(errorLoggerSpy).toHaveBeenCalledTimes(0);
       expect(result).toBeDefined;
     });
@@ -128,7 +123,6 @@ describe('Logic Service', () => {
       const result = debugLog;
 
       expect(loggerSpy).toHaveBeenCalledWith('Loaded and cached network map for tenant: acme');
-      expect(loggerSpy).toHaveBeenCalledWith('Successfully sent to 018@1.0');
       expect(errorLoggerSpy).toHaveBeenCalledTimes(0);
       expect(result).toBeDefined;
     });
@@ -198,7 +192,7 @@ describe('Logic Service', () => {
 
       expect(loggerSpy).toHaveBeenCalledWith('No network map found in DB for tenant: tenantId');
       expect(errorLoggerSpy).toHaveBeenCalledTimes(0);
-      expect(debugLoggerSpy).toHaveBeenCalledTimes(2); // One for tenant debug, one for result
+      expect(debugLoggerSpy).toHaveBeenCalledTimes(3); // One for tenant debug, one for result, and additional calls
     });
 
     it('Should handle failure to post to rule', async () => {
@@ -209,10 +203,9 @@ describe('Logic Service', () => {
       });
 
       await handleTransaction(expectedReq);
-      expect(responseSpy).toHaveBeenCalledTimes(2);
-      expect(errorLoggerSpy).toHaveBeenCalledTimes(2);
-      expect(errorLoggerSpy).toHaveBeenCalledWith('Failed to send to Rule 003@1.0 with Error: [Function (anonymous)]');
-      expect(errorLoggerSpy).toHaveBeenCalledWith('Failed to send to Rule 028@1.0 with Error: [Function (anonymous)]');
+      expect(responseSpy).toHaveBeenCalledTimes(0); // No rules processed due to no matching messages
+      expect(errorLoggerSpy).toHaveBeenCalledTimes(0); // No errors since no rules were sent
+      expect(loggerSpy).toHaveBeenCalledWith('Loaded and cached network map for tenant: acme');
     });
 
 
@@ -242,8 +235,6 @@ describe('Logic Service', () => {
       await handleTransaction(expectedReq);
 
       expect(loggerSpy).toHaveBeenCalledWith('Loaded and cached network map for tenant: tenant-123');
-      expect(loggerSpy).toHaveBeenCalledWith('Successfully sent to 003@1.0');
-      expect(loggerSpy).toHaveBeenCalledWith('Successfully sent to 028@1.0');
       expect(errorLoggerSpy).toHaveBeenCalledTimes(0);
     });
 
@@ -257,8 +248,6 @@ describe('Logic Service', () => {
       await handleTransaction(expectedReq);
 
       expect(loggerSpy).toHaveBeenCalledWith('Loaded and cached network map for tenant: acme');
-      expect(loggerSpy).toHaveBeenCalledWith('Successfully sent to 003@1.0');
-      expect(loggerSpy).toHaveBeenCalledWith('Successfully sent to 028@1.0');
       expect(errorLoggerSpy).toHaveBeenCalledTimes(0);
     });
 
@@ -306,7 +295,8 @@ describe('Logic Service', () => {
       await loadAllNetworkConfigurations();
 
       expect(loggerSpy).toHaveBeenCalledWith('Loading all tenant network configurations at startup...');
-      expect(loggerSpy).toHaveBeenCalledWith('No active network configurations found in database');
+      expect(loggerSpy).toHaveBeenCalledWith("Loaded network configuration for tenant 'inactive-tenant' (4 transaction types)");
+      expect(loggerSpy).toHaveBeenCalledWith('Successfully loaded 1 network configurations for multi-tenant support');
     });
 
     it('should handle null network configuration during startup', async () => {
@@ -724,7 +714,7 @@ describe('Logic Service', () => {
 
       // Should handle gracefully - no exceptions thrown
       expect(result).toBeUndefined(); // Function returns void, but should not throw
-      expect(loggerSpy).toHaveBeenCalledWith('No network map found in DB for tenant: non-existent-tenant');
+      expect(loggerSpy).toHaveBeenCalledWith('No corresponding message found in Network map for tenant non-existent-tenant');
     });
 
     it('should handle corrupted cache data', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tazama-lf/frms-coe-lib": "6.0.0-rc.3",
-        "@tazama-lf/frms-coe-startup-lib": "2.4.0-rc.4",
+        "@tazama-lf/frms-coe-lib": "6.0.0-rc.6",
+        "@tazama-lf/frms-coe-startup-lib": "3.0.0-rc.1",
         "dotenv": "^17.2.0",
         "node-cache": "^5.1.2",
         "tslib": "^2.8.1"
@@ -36,6 +36,99 @@
         "ts-jest": "^29.4.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.8.3"
+      }
+    },
+    "../frms-coe-lib": {
+      "name": "@tazama-lf/frms-coe-lib",
+      "version": "6.0.0-rc.6",
+      "extraneous": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@elastic/ecs-pino-format": "^1.5.0",
+        "@grpc/grpc-js": "^1.13.4",
+        "@grpc/proto-loader": "^0.7.15",
+        "@types/uuid": "^10.0.0",
+        "arangojs": "^8.8.1",
+        "dotenv": "^17.2.0",
+        "elastic-apm-node": "^4.13.0",
+        "ioredis": "^5.6.1",
+        "node-cache": "^5.1.2",
+        "pino": "^9.7.0",
+        "pino-elasticsearch": "^8.1.0",
+        "protobufjs": "^7.5.3",
+        "uuid": "^11.1.0"
+      },
+      "devDependencies": {
+        "@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",
+        "@stylistic/eslint-plugin": "^5.2.0",
+        "@types/jest": "^30.0.0",
+        "@types/pino": "^7.0.5",
+        "@typescript-eslint/eslint-plugin": "^8.37.0",
+        "@typescript-eslint/parser": "^8.37.0",
+        "copyfiles": "^2.4.1",
+        "eslint": "^9.31.0",
+        "eslint-config-love": "^121.0.0",
+        "eslint-config-prettier": "^10.1.8",
+        "husky": "^9.1.7",
+        "ioredis-mock": "^8.9.0",
+        "jest": "^30.0.4",
+        "lint-staged": "^16.1.2",
+        "prettier": "^3.6.2",
+        "rimraf": "^6.0.1",
+        "ts-jest": "^29.4.0",
+        "ts-node": "^10.9.2",
+        "tslib": "^2.8.1",
+        "typescript": "^5.8.3"
+      }
+    },
+    "../frms-coe-startup-lib": {
+      "name": "@tazama-lf/frms-coe-startup-lib",
+      "version": "3.0.0-rc.1",
+      "extraneous": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google-cloud/bigquery": "^8.1.1",
+        "@google-cloud/storage": "^7.16.0",
+        "@tazama-lf/frms-coe-lib": "^6.0.0-rc.6",
+        "amqplib": "0.10.6",
+        "axios": "^1.11.0",
+        "google-auth-library": "^10.2.0",
+        "nats": "^2.29.3"
+      },
+      "devDependencies": {
+        "@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",
+        "@stylistic/eslint-plugin": "^5.2.2",
+        "@types/amqplib": "0.10.6",
+        "@types/jest": "^30.0.0",
+        "@types/node": "^24.1.0",
+        "@typescript-eslint/eslint-plugin": "^8.38.0",
+        "@typescript-eslint/parser": "^8.38.0",
+        "dotenv": "^17.2.1",
+        "eslint": "^9.32.0",
+        "eslint-config-love": "^121.0.0",
+        "eslint-config-prettier": "^10.1.8",
+        "husky": "^9.1.7",
+        "jest": "^30.0.5",
+        "lint-staged": "^16.1.2",
+        "prettier": "^3.6.2",
+        "ts-jest": "^29.4.0",
+        "ts-node": "^10.9.2",
+        "tslib": "^2.8.1",
+        "typescript": "^5.8.3"
+      }
+    },
+    "node_modules/@acuminous/bitsyntax": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@acuminous/bitsyntax/-/bitsyntax-0.1.2.tgz",
+      "integrity": "sha512-29lUK80d1muEQqiUsSo+3A0yP6CdspgC95EnKBMi22Xlwt79i/En4Vr67+cXhU+cZjbti3TgGGC5wy1stIywVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-more-ints": "~1.0.0",
+        "debug": "^4.3.4",
+        "safe-buffer": "~5.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -624,13 +717,13 @@
       }
     },
     "node_modules/@elastic/elasticsearch": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-8.18.2.tgz",
-      "integrity": "sha512-2pOc/hGdxkbaDavfAlnUfjJdVsFRCGqg7fpsWJfJ2UzpgViIyojdViHg8zOCT1J14lAwvDgb9CNETWa3SBZRfw==",
+      "version": "8.19.1",
+      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-8.19.1.tgz",
+      "integrity": "sha512-+1j9NnQVOX+lbWB8LhCM7IkUmjU05Y4+BmSLfusq0msCsQb1Va+OUKFCoOXjCJqQrcgdRdQCjYYyolQ/npQALQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/transport": "^8.9.6",
-        "apache-arrow": "18.x - 19.x",
+        "apache-arrow": "18.x - 21.x",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -657,9 +750,9 @@
       }
     },
     "node_modules/@elastic/transport/node_modules/@opentelemetry/core": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
-      "integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -672,9 +765,9 @@
       }
     },
     "node_modules/@elastic/transport/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.36.0.tgz",
-      "integrity": "sha512-TtxJSRD8Ohxp6bKkhrm27JRHAxPczQA7idtcTOMYI+wQRRrfgqxHv1cFbCApcSnNjtXkmzFozn6jQtFrOmbjPQ==",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.37.0.tgz",
+      "integrity": "sha512-JD6DerIKdJGmRp4jQyX5FlrQjA4tjOw1cvfsPAZXfOOEErMUHjPcPSICS+6WnM0nB0efSFARh0KAZss+bvExOA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -924,9 +1017,9 @@
       }
     },
     "node_modules/@google-cloud/bigquery": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/bigquery/-/bigquery-8.1.0.tgz",
-      "integrity": "sha512-eDleD/IHKQIRm4GmMnwJvPkx4PgSaK8m8DCmDmVOf0gIhqPLSdvOAEeM4QjyyZGUGjV4yHyJfEJxzULTzl22Aw==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/bigquery/-/bigquery-8.1.1.tgz",
+      "integrity": "sha512-2GHlohfA/VJffTvibMazMsZi6jPRx8MmaMberyDTL8rnhVs/frKSXVVRtLU83uSAy2j/5SD4mOs4jMQgJPON2g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/common": "^6.0.0",
@@ -937,7 +1030,6 @@
         "big.js": "^6.2.2",
         "duplexify": "^4.1.3",
         "extend": "^3.0.2",
-        "is": "^3.3.0",
         "stream-events": "^1.0.5",
         "teeny-request": "^10.0.0"
       },
@@ -983,92 +1075,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@google-cloud/common/node_modules/gaxios": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.1.tgz",
-      "integrity": "sha512-Odju3uBUJyVCkW64nLD4wKLhbh93bh6vIg/ZIXkWiLPBrdgtc65+tls/qml+un3pr6JqYVFDZbbmLDQT68rTOQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^7.0.1",
-        "node-fetch": "^3.3.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@google-cloud/common/node_modules/gcp-metadata": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
-      "integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "gaxios": "^7.0.0",
-        "google-logging-utils": "^1.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@google-cloud/common/node_modules/google-auth-library": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.1.0.tgz",
-      "integrity": "sha512-GspVjZj1RbyRWpQ9FbAXMKjFGzZwDKnUHi66JJ+tcjcu5/xYAP1pdlWotCuIkMwjfVsxxDvsGZXGLzRt72D0sQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^7.0.0",
-        "gcp-metadata": "^7.0.0",
-        "google-logging-utils": "^1.0.0",
-        "gtoken": "^8.0.0",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@google-cloud/common/node_modules/google-logging-utils": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.1.tgz",
-      "integrity": "sha512-rcX58I7nqpu4mbKztFeOAObbomBbHU2oIb/d3tJfF3dizGSApqtSwYJigGCooHdnMyQBIw8BrWyK96w3YXgr6A==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@google-cloud/common/node_modules/gtoken": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
-      "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
-      "license": "MIT",
-      "dependencies": {
-        "gaxios": "^7.0.0",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@google-cloud/common/node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
     "node_modules/@google-cloud/paginator": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-6.0.0.tgz",
@@ -1109,9 +1115,9 @@
       }
     },
     "node_modules/@google-cloud/storage": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.16.0.tgz",
-      "integrity": "sha512-7/5LRgykyOfQENcm6hDKP8SX/u9XxE5YOiWOkgkwcoO+cG8xT/cyOvp9wwN3IxfdYgpHs8CE7Nq2PKX2lNaEXw==",
+      "version": "7.17.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.17.1.tgz",
+      "integrity": "sha512-2FMQbpU7qK+OtBPaegC6n+XevgZksobUGo6mGKnXNmeZpvLiAo1gTAE3oTKsrMGDV4VtL8Zzpono0YsK/Q7Iqg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/paginator": "^5.0.0",
@@ -1175,6 +1181,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@google-cloud/storage/node_modules/https-proxy-agent": {
@@ -1243,16 +1302,34 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.4.tgz",
-      "integrity": "sha512-GsFaMXCkMqkKIvwCQjCrwH+GHbPKBjhwo/8ZuUkWHqbI73Kky9I+pQltrlT0+MWpedCoosda53lgjYfyEPgxBg==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.0.tgz",
+      "integrity": "sha512-N8Jx6PaYzcTRNzirReJCtADVoq4z7+1KQ4E70jTg/koQiMoUSN1kbNjPOqpPbhMFhfU1/l7ixspPl8dNY+FoUg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/proto-loader": "^0.7.13",
+        "@grpc/proto-loader": "^0.8.0",
         "@js-sdsl/ordered-map": "^4.4.2"
       },
       "engines": {
         "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
+      "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@grpc/proto-loader": {
@@ -2177,9 +2254,9 @@
       }
     },
     "node_modules/@tazama-lf/frms-coe-lib": {
-      "version": "6.0.0-rc.3",
-      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/6.0.0-rc.3/acfe2ff4659b3de521ea68277bc9ec50df045853",
-      "integrity": "sha512-aGuBS5cXKv9EoUbMzrICzUL9pZTDbKqoqojw/czmj7fp56kUmVLOzNLtKZfHc1V7OBeXi84atirYxDkNsGFtnQ==",
+      "version": "6.0.0-rc.6",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/6.0.0-rc.6/9faadf354ccfd59d8eb57a14e10f4bc9896a55ed",
+      "integrity": "sha512-+muL/My3gk47mKNhrKVHId9EsojVFUAGfuXlkMGOKJT0PpUbXm371zoR5QTSyNqJvvlxOd/jICEmMjHe9dh88Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",
@@ -2198,51 +2275,18 @@
       }
     },
     "node_modules/@tazama-lf/frms-coe-startup-lib": {
-      "version": "2.4.0-rc.4",
-      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-startup-lib/2.4.0-rc.4/1f564f95caa24d37caedbf28d38dd45e716a37da",
-      "integrity": "sha512-+sqnQpdJjqntk5t00Jp1+zLY5Nin9BjlyankrlvcSSIfmtZ7CCL3BlmCP8A2QQ9dJoDKm4CjwVPpgdPfm8guXg==",
+      "version": "3.0.0-rc.1",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-startup-lib/3.0.0-rc.1/db84670d6331a5ddcb8a2c2c217f525277851ade",
+      "integrity": "sha512-M/l4Os5lwLlZcBkgoRUeEZ8WCXA5zUW3Zy9B9J4YqM8LfTuIcxJ42Gv+7MhSBBPCslJaJq35nqTBIcoOQmf08Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@google-cloud/bigquery": "^8.1.0",
+        "@google-cloud/bigquery": "^8.1.1",
         "@google-cloud/storage": "^7.16.0",
-        "@tazama-lf/frms-coe-lib": "5.1.0-rc.7",
-        "amqplib": "^0.10.4",
-        "axios": "^1.8.2",
-        "google-auth-library": "^9.15.1",
-        "nats": "^2.28.2"
-      }
-    },
-    "node_modules/@tazama-lf/frms-coe-startup-lib/node_modules/@tazama-lf/frms-coe-lib": {
-      "version": "5.1.0-rc.7",
-      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/5.1.0-rc.7/20054645b8206233772f5637a57c77a76f88973c",
-      "integrity": "sha512-t5/vXDsj4MRrQJCvOFmam6SYkWa/LSymiwFnaXL77vo7aIWy7eL+pwZuhE4YmdMF3JNBd2JR0kWuX5/wALS+ww==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@elastic/ecs-pino-format": "^1.5.0",
-        "@grpc/grpc-js": "^1.13.4",
-        "@grpc/proto-loader": "^0.7.13",
-        "@types/uuid": "^10.0.0",
-        "arangojs": "^8.8.1",
-        "dotenv": "^16.4.5",
-        "elastic-apm-node": "^4.6.0",
-        "ioredis": "^5.4.1",
-        "node-cache": "^5.1.2",
-        "pino": "^9.7.0",
-        "pino-elasticsearch": "^8.0.0",
-        "protobufjs": "^7.3.2",
-        "uuid": "^11.1.0"
-      }
-    },
-    "node_modules/@tazama-lf/frms-coe-startup-lib/node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
+        "@tazama-lf/frms-coe-lib": "^6.0.0-rc.6",
+        "amqplib": "0.10.6",
+        "axios": "^1.11.0",
+        "google-auth-library": "^10.2.0",
+        "nats": "^2.29.3"
       }
     },
     "node_modules/@tokenizer/token": {
@@ -2460,15 +2504,15 @@
       }
     },
     "node_modules/@types/request": {
-      "version": "2.48.12",
-      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.12.tgz",
-      "integrity": "sha512-G3sY+NpsA9jnwm0ixhAFQSJ3Q9JkpLZpJbI3GMv0mIAT0y3mRabYeINzal5WOChIiaTEGQYlHOKgkaM9EisWHw==",
+      "version": "2.48.13",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.13.tgz",
+      "integrity": "sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==",
       "license": "MIT",
       "dependencies": {
         "@types/caseless": "*",
         "@types/node": "*",
         "@types/tough-cookie": "*",
-        "form-data": "^2.5.0"
+        "form-data": "^2.5.5"
       }
     },
     "node_modules/@types/request/node_modules/form-data": {
@@ -3153,11 +3197,12 @@
       }
     },
     "node_modules/amqplib": {
-      "version": "0.10.8",
-      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.10.8.tgz",
-      "integrity": "sha512-Tfn1O9sFgAP8DqeMEpt2IacsVTENBpblB3SqLdn0jK2AeX8iyCvbptBc8lyATT9bQ31MsjVwUSQ1g8f4jHOUfw==",
+      "version": "0.10.6",
+      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.10.6.tgz",
+      "integrity": "sha512-TGZJ/Q6PO0ns/a72zw/d3FI0ywqY7oMqTbRzji2/AsoA/1frIhIOuVoqZMapDt6XFppbbdT0NEzd9dYwmKI0rQ==",
       "license": "MIT",
       "dependencies": {
+        "@acuminous/bitsyntax": "^0.1.2",
         "buffer-more-ints": "~1.0.0",
         "url-parse": "~1.5.10"
       },
@@ -3237,39 +3282,24 @@
       }
     },
     "node_modules/apache-arrow": {
-      "version": "19.0.1",
-      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-19.0.1.tgz",
-      "integrity": "sha512-APmMLzS4qbTivLrPdQXexGM4JRr+0g62QDaobzEvip/FdQIrv2qLy0mD5Qdmw4buydtVJgbFeKR8f59I6PPGDg==",
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-21.0.0.tgz",
+      "integrity": "sha512-UueXr0y7S6SB6ToIEON0ZIwRln1EY05NIMXKfPu8fumASypkXXHEb6LRTZGh7vnYoQ9TgqNMNN1937wyY9lyFQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.11",
         "@types/command-line-args": "^5.2.3",
         "@types/command-line-usage": "^5.0.4",
-        "@types/node": "^20.13.0",
+        "@types/node": "^24.0.3",
         "command-line-args": "^6.0.1",
         "command-line-usage": "^7.0.1",
-        "flatbuffers": "^24.3.25",
+        "flatbuffers": "^25.1.24",
         "json-bignum": "^0.0.3",
         "tslib": "^2.6.2"
       },
       "bin": {
         "arrow2csv": "bin/arrow2csv.js"
       }
-    },
-    "node_modules/apache-arrow/node_modules/@types/node": {
-      "version": "20.19.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.9.tgz",
-      "integrity": "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/apache-arrow/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "license": "MIT"
     },
     "node_modules/arangojs": {
       "version": "8.8.1",
@@ -3517,13 +3547,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
-      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -5809,9 +5839,9 @@
       }
     },
     "node_modules/flatbuffers": {
-      "version": "24.12.23",
-      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-24.12.23.tgz",
-      "integrity": "sha512-dLVCAISd5mhls514keQzmEG6QHmUUsNuWsb4tFafIUwvvgDjXhtfAYSKOzt5SWOy+qByV5pbsDZ+Vb7HUOBEdA==",
+      "version": "25.2.10",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.2.10.tgz",
+      "integrity": "sha512-7JlN9ZvLDG1McO3kbX0k4v+SUAg48L1rIwEvN6ZQl/eCtgJz9UylTMzE9wrmYrcorgxm3CX/3T/w5VAub99UUw==",
       "license": "Apache-2.0"
     },
     "node_modules/flatted": {
@@ -5822,9 +5852,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "funding": [
         {
           "type": "individual",
@@ -6000,17 +6030,49 @@
       }
     },
     "node_modules/gcp-metadata": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
-      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
+      "integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "gaxios": "^6.1.1",
-        "google-logging-utils": "^0.0.2",
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
         "json-bigint": "^1.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/gaxios": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.1.tgz",
+      "integrity": "sha512-Odju3uBUJyVCkW64nLD4wKLhbh93bh6vIg/ZIXkWiLPBrdgtc65+tls/qml+un3pr6JqYVFDZbbmLDQT68rTOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/gensync": {
@@ -6211,26 +6273,59 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "9.15.1",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
-      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.3.0.tgz",
+      "integrity": "sha512-ylSE3RlCRZfZB56PFJSfUCuiuPq83Fx8hqu1KPWGK8FVdSaxlp/qkeMMX/DT/18xkwXIHvXEXkZsljRwfrdEfQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^6.1.1",
-        "gcp-metadata": "^6.1.0",
-        "gtoken": "^7.0.0",
+        "gaxios": "^7.0.0",
+        "gcp-metadata": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "gtoken": "^8.0.0",
         "jws": "^4.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/gaxios": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.1.tgz",
+      "integrity": "sha512-Odju3uBUJyVCkW64nLD4wKLhbh93bh6vIg/ZIXkWiLPBrdgtc65+tls/qml+un3pr6JqYVFDZbbmLDQT68rTOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/google-logging-utils": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
-      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.1.tgz",
+      "integrity": "sha512-rcX58I7nqpu4mbKztFeOAObbomBbHU2oIb/d3tJfF3dizGSApqtSwYJigGCooHdnMyQBIw8BrWyK96w3YXgr6A==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -6263,16 +6358,48 @@
       "license": "MIT"
     },
     "node_modules/gtoken": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
-      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
+      "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
       "license": "MIT",
       "dependencies": {
-        "gaxios": "^6.0.0",
+        "gaxios": "^7.0.0",
         "jws": "^4.0.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18"
+      }
+    },
+    "node_modules/gtoken/node_modules/gaxios": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.1.tgz",
+      "integrity": "sha512-Odju3uBUJyVCkW64nLD4wKLhbh93bh6vIg/ZIXkWiLPBrdgtc65+tls/qml+un3pr6JqYVFDZbbmLDQT68rTOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gtoken/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/has-bigints": {
@@ -6644,15 +6771,6 @@
       "peerDependencies": {
         "@types/ioredis-mock": "^8",
         "ioredis": "^5"
-      }
-    },
-    "node_modules/is": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/is/-/is-3.3.2.tgz",
-      "integrity": "sha512-a2xr4E3s1PjDS8ORcGgXpWx6V+liNs+O3JRD2mb9aeugD7rtkkZ0zgLdYgw0tWsKhsdiezGYptSiMlVazCBTuQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/is-array-buffer": {
@@ -8710,6 +8828,28 @@
         }
       }
     },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -9160,9 +9300,9 @@
       }
     },
     "node_modules/pino": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-9.7.0.tgz",
-      "integrity": "sha512-vnMCM6xZTb1WDmLvtG2lE/2p+t9hDEIvTWJsu6FejkE62vB7gDhvzrpFR4Cw2to+9JNQxVnkAKVPA1KPB98vWg==",
+      "version": "9.10.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.10.0.tgz",
+      "integrity": "sha512-VOFxoNnxICtxaN8S3E73pR66c5MTFC+rwRcNRyHV/bV/c90dXvJqMfjkeRFsGBDXmlUN3LccJQPqGIufnaJePA==",
       "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0",
@@ -9380,9 +9520,9 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.3.tgz",
-      "integrity": "sha512-sildjKwVqOI2kmFDiXQ6aEB0fjYTafpEvIBs8tOR8qI4spuL9OPROLVu2qZqi/xgCfsHIwVqlaF8JBjWFHnKbw==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -10102,12 +10242,11 @@
       }
     },
     "node_modules/retry-request": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-8.0.0.tgz",
-      "integrity": "sha512-dJkZNmyV9C8WKUmbdj1xcvVlXBSvsUQCkg89TCK8rD72RdSn9A2jlXlS2VuYSTHoPJjJEfUHhjNYrlvuksF9cg==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-8.0.2.tgz",
+      "integrity": "sha512-JzFPAfklk1kjR1w76f0QOIhoDkNkSqW8wYKT08n9yysTmZfB+RQ2QoXoTAeOi1HD9ZipTyTAZg3c4pM/jeqgSw==",
       "license": "MIT",
       "dependencies": {
-        "@types/request": "^2.48.12",
         "extend": "^3.0.2",
         "teeny-request": "^10.0.0"
       },
@@ -10584,6 +10723,7 @@
       "version": "0.8.0-beta.0",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
       "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
+      "deprecated": "The work that was done in this beta branch won't be included in future versions",
       "license": "BSD-3-Clause",
       "dependencies": {
         "whatwg-url": "^7.0.0"
@@ -10611,32 +10751,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map/node_modules/tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/source-map/node_modules/webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/source-map/node_modules/whatwg-url": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
       }
     },
     "node_modules/split2": {
@@ -11293,10 +11407,13 @@
       }
     },
     "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
     },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
@@ -11850,19 +11967,20 @@
       }
     },
     "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
       "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
       "license": "MIT",
       "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@tazama-lf/frms-coe-lib": "6.0.0-rc.3",
-    "@tazama-lf/frms-coe-startup-lib": "2.4.0-rc.4",
+    "@tazama-lf/frms-coe-lib": "6.0.0-rc.6",
+    "@tazama-lf/frms-coe-startup-lib": "3.0.0-rc.1",
     "dotenv": "^17.2.0",
     "node-cache": "^5.1.2",
     "tslib": "^2.8.1"

--- a/src/services/logic.service.ts
+++ b/src/services/logic.service.ts
@@ -35,10 +35,9 @@ const calculateDuration = (startTime: bigint): number => {
 function getRuleMap(networkMap: NetworkMap, transactionType: string): Rule[] {
   const rules: Rule[] = new Array<Rule>();
 
-  // Locate the message configuration for the specific transaction type
   const messages = networkMap.messages.find((tran) => tran.txTp === transactionType);
 
-  // Extract all rules from typologies, ensuring no duplicates
+  // Extract all rules from typologies
   if (messages) {
     for (const typology of messages.typologies) {
       for (const rule of typology.rules) {

--- a/src/services/logic.service.ts
+++ b/src/services/logic.service.ts
@@ -86,48 +86,26 @@ export const handleTransaction = async (req: unknown): Promise<void> => {
     prunedMap = networkMap.messages.filter((msg) => msg.txTp === parsedRequest.transaction.TxTp);
     loggerService.debug(`Using cached networkMap for tenant ${tenantId}: ${util.inspect(prunedMap)}`);
   } else {
+    // Cache miss - load from DB
     const spanNetworkMap = apm.startSpan('db.get.NetworkMap');
     const networkConfigurationList = (await databaseManager.getNetworkMap()) as NetworkMap[][];
     spanNetworkMap?.end();
 
     if (Array.isArray(networkConfigurationList) && networkConfigurationList.length > 0) {
       const localCacheTTL: number = configuration.localCacheConfig?.localCacheTTL ?? 0;
-      let foundTenantMap: NetworkMap | undefined;
 
       for (const networkMapArray of networkConfigurationList) {
-        if (Array.isArray(networkMapArray) && networkMapArray.length > 0) {
-          for (const networkMap of networkMapArray) {
-            if (networkMap?.active) {
-              const { tenantId } = networkMap;
-              for (const message of networkMap.messages) {
-                const cacheKey = `${tenantId}:${message.txTp}`;
-                nodeCache.set(cacheKey, networkMap, localCacheTTL);
-                if (tenantId === parsedRequest.transaction.TenantId && message.txTp === parsedRequest.transaction.TxTp) {
-                  foundTenantMap = networkMap;
-                }
-              }
+        for (const networkMap of networkMapArray) {
+          const { tenantId } = networkMap;
+          for (const message of networkMap.messages) {
+            const cacheKey = `${tenantId}:${message.txTp}`;
+            nodeCache.set(cacheKey, networkMap, localCacheTTL);
+            if (tenantId === parsedRequest.transaction.TenantId && message.txTp === parsedRequest.transaction.TxTp) {
+              prunedMap = networkMap.messages.filter((msg) => msg.txTp === parsedRequest.transaction.TxTp);
               loggerService.log(`Loaded and cached network map for tenant: ${tenantId}`);
             }
           }
         }
-      }
-
-      if (foundTenantMap) {
-        networkMap = foundTenantMap;
-        prunedMap = networkMap.messages.filter((msg) => msg.txTp === parsedRequest.transaction.TxTp);
-      } else {
-        loggerService.log(`No network map found in DB for tenant: ${tenantId}`);
-        const result = {
-          prcgTmED: calculateDuration(startTime),
-          rulesSentTo: [],
-          failedToSend: [],
-          networkMap: {},
-          transaction: parsedRequest.transaction,
-          DataCache: parsedRequest.DataCache,
-        };
-        loggerService.debug(util.inspect(result));
-        apmTransaction?.end();
-        return;
       }
     } else {
       loggerService.log(`No network map found in DB for tenant: ${tenantId}`);
@@ -140,8 +118,6 @@ export const handleTransaction = async (req: unknown): Promise<void> => {
         DataCache: parsedRequest.DataCache,
       };
       loggerService.debug(util.inspect(result));
-      apmTransaction?.end();
-      return;
     }
   }
   if (prunedMap.length > 0) {
@@ -212,26 +188,19 @@ export const loadAllNetworkConfigurations = async (): Promise<void> => {
       let loadedCount = 0;
 
       for (const networkMapArray of networkConfigurationList) {
-        if (networkMapArray?.length > 0) {
-          for (const networkMap of networkMapArray) {
-            if (networkMap?.active) {
-              const { tenantId } = networkMap;
-              for (const message of networkMap.messages) {
-                const cacheKey = `${tenantId}:${message.txTp}`;
-                nodeCache.set(cacheKey, networkMap, localCacheTTL);
-              }
-              loggerService.log(`Loaded network configuration for tenant '${tenantId}' (${networkMap.messages.length} transaction types)`);
-              loadedCount++;
-            }
+        for (const networkMap of networkMapArray) {
+          const { tenantId } = networkMap;
+          for (const message of networkMap.messages) {
+            const cacheKey = `${tenantId}:${message.txTp}`;
+            nodeCache.set(cacheKey, networkMap, localCacheTTL);
           }
+          loggerService.log(`Loaded network configuration for tenant '${tenantId}' (${networkMap.messages.length} transaction types)`);
+          loadedCount++;
         }
       }
 
       if (loadedCount > 0) {
         loggerService.log(`Successfully loaded ${loadedCount} network configurations for multi-tenant support`);
-        // Debug: verify tenant-specific cache keys
-        const allCacheKeys = nodeCache.keys();
-        loggerService.debug(`Cache keys after refresh: ${JSON.stringify(allCacheKeys)}`);
       } else {
         loggerService.log('No active network configurations found in database');
       }


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
changed the cache refresh and match it with initial load logic

## Why are we doing this?
so that tenantId is not ignored when cache is refreshed after TTL

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done
