### PR TITLE
build: bump version to 4.0.0-rc.2 and align service-channel deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "event-director",
-  "version": "4.0.0-rc.1",
+  "version": "4.0.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "event-director",
-      "version": "4.0.0-rc.1",
+      "version": "4.0.0-rc.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tazama-lf/frms-coe-lib": "8.2.0-rc.1",
-        "@tazama-lf/frms-coe-startup-lib": "3.1.0-rc.2",
+        "@tazama-lf/frms-coe-lib": "8.2.0-rc.3",
+        "@tazama-lf/frms-coe-startup-lib": "3.1.0-rc.7",
         "dotenv": "^17.2.1",
         "node-cache": "^5.1.2",
         "tslib": "^2.8.1"
@@ -1858,9 +1858,9 @@
       }
     },
     "node_modules/@tazama-lf/frms-coe-lib": {
-      "version": "8.2.0-rc.1",
-      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/8.2.0-rc.1/763f21ed32311ac31a03779b2af2d75cf1c49b6e",
-      "integrity": "sha512-VUUQVNz12mHVjmOEwJSKtLRD/zQx0UBnZ3AxCnNkkUjFHK0nVJUtltdwkTApHlQnUbOR3emdEvjAYim21gFmmA==",
+      "version": "8.2.0-rc.3",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/8.2.0-rc.3/2261d253248dfe63cbdb9445ba6786fad5ef17a4",
+      "integrity": "sha512-Kevho3L6RZvTNq5yBJE55smj3pkNmp5obUBcq/THOuHRxIzSoCQZJfbKH2bjYEOQkn2I+8FhUvyKje9eZJ2qaQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",
@@ -1883,12 +1883,12 @@
       }
     },
     "node_modules/@tazama-lf/frms-coe-startup-lib": {
-      "version": "3.1.0-rc.2",
-      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-startup-lib/3.1.0-rc.2/fd32b1d35ab6f524de7590615b2be300dbe7b691",
-      "integrity": "sha512-ch3HOQgOnyoJD+akcD7qgZM/WcRISHxIAROGkMcfNdLadeaEgnqZJ8Y5RNkjn+yWjwyBhVs+bLrZGZgi2XWwUg==",
+      "version": "3.1.0-rc.7",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-startup-lib/3.1.0-rc.7/4baf4d53e1daea9369f3ddb5c6dded14422fe6b7",
+      "integrity": "sha512-MfwaPGfdXckSkH+9jJjc7NwCdTK8HqleJ+5iDt4x7q/QFMoEp3N0E3dwDKLZ5icCzG4jEhjFZfYAfBZXq+G3ew==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tazama-lf/frms-coe-lib": "8.2.0-rc.1",
+        "@tazama-lf/frms-coe-lib": "8.2.0-rc.3",
         "amqplib": "0.10.6",
         "axios": "^1.13.5",
         "nats": "^2.29.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "event-director",
-  "version": "4.0.0-rc.1",
+  "version": "4.0.0-rc.2",
   "description": "predicate-builder-service",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -37,8 +37,8 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@tazama-lf/frms-coe-lib": "8.2.0-rc.1",
-    "@tazama-lf/frms-coe-startup-lib": "3.1.0-rc.2",
+    "@tazama-lf/frms-coe-lib": "8.2.0-rc.3",
+    "@tazama-lf/frms-coe-startup-lib": "3.1.0-rc.7",
     "dotenv": "^17.2.1",
     "node-cache": "^5.1.2",
     "tslib": "^2.8.1"


### PR DESCRIPTION
## What

Dependency alignment for the service-channel epic.

- `version`: `4.0.0-rc.1` -> `4.0.0-rc.2`
- `@tazama-lf/frms-coe-lib`: `8.2.0-rc.1` -> `8.2.0-rc.3`
- `@tazama-lf/frms-coe-startup-lib`: `3.1.0-rc.2` -> `3.1.0-rc.7`

## Why

Brings event-director onto the current service-channel baseline shared across
typology-processor, event-adjudicator and admin-service, ahead of upcoming work
on this branch.

## Validation

- `npm install` - lockfile resolves `frms-coe-lib 8.2.0-rc.3`, `frms-coe-startup-lib 3.1.0-rc.7`
- `npm test` - 56/56 pass
- `npm run build` - clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 4.0.0-rc.2
  * Updated dependencies for improved stability and performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->