### PR TITLE
fix: bump frms-coe-startup-lib to 3.1.0-rc.9 for axios CVE remediation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "event-director",
-  "version": "4.0.0-rc.2",
+  "version": "4.0.0-rc.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "event-director",
-      "version": "4.0.0-rc.2",
+      "version": "4.0.0-rc.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@tazama-lf/frms-coe-lib": "8.2.0-rc.6",
-        "@tazama-lf/frms-coe-startup-lib": "3.1.0-rc.8",
+        "@tazama-lf/frms-coe-startup-lib": "3.1.0-rc.9",
         "dotenv": "^17.2.1",
         "node-cache": "^5.1.2",
         "tslib": "^2.8.1"
@@ -1860,14 +1860,14 @@
       }
     },
     "node_modules/@tazama-lf/frms-coe-startup-lib": {
-      "version": "3.1.0-rc.8",
-      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-startup-lib/3.1.0-rc.8/65158cc89ae26c324d2f2958e4d4eeec620d4aa7",
-      "integrity": "sha512-rjgyf0eGg+2FfSk2wgfxRZjZbEleBq6nUu11Ph/ggMOvNMuejxP+5nI7ig6wqut8PqBqUKNibNKA/iNsMMme/w==",
+      "version": "3.1.0-rc.9",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-startup-lib/3.1.0-rc.9/9a0a62305de53441354df30da5aa4d90b7752369",
+      "integrity": "sha512-dZtAnrxuBcdS8YPfH4xw3NFo+nfUgr61VxNUdH+pKWVVxieDtWSAnQFuD7GmRZ6sXkUyB5HYoBBa61xfIdpOqA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@tazama-lf/frms-coe-lib": "8.2.0-rc.6",
         "amqplib": "0.10.6",
-        "axios": "^1.13.5",
+        "axios": "^1.18.1",
         "nats": "^2.29.3"
       }
     },
@@ -2676,6 +2676,18 @@
       "integrity": "sha512-2zHEyuhSJOuCrmas9YV0YL/MFCWLxe1dS6k/ENhgYrb/JqyMnadLN4iIAc9kkZrbElMDyyAGH/0J18OPErOWLg==",
       "license": "MIT"
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/agentkeepalive": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
@@ -3065,13 +3077,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -5800,6 +5813,19 @@
       "license": "MIT",
       "dependencies": {
         "next-line": "^1.1.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/human-signals": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@tazama-lf/frms-coe-lib": "8.2.0-rc.6",
-    "@tazama-lf/frms-coe-startup-lib": "3.1.0-rc.8",
+    "@tazama-lf/frms-coe-startup-lib": "3.1.0-rc.9",
     "dotenv": "^17.2.1",
     "node-cache": "^5.1.2",
     "tslib": "^2.8.1"


### PR DESCRIPTION
# fix: bump frms-coe-startup-lib to 3.1.0-rc.9 for axios CVE remediation

## Why

Part of the platform-wide axios remediation for the June 2026 advisory batch (CVE-2026-44486..44496 plus the June GHSA wave). `event-director` has no direct axios dependency - it inherited a vulnerable axios transitively through `@tazama-lf/frms-coe-startup-lib`.

## What

- `package.json`: `@tazama-lf/frms-coe-startup-lib 3.1.0-rc.8` -> `3.1.0-rc.9` (the axios-remediated RC)
- `package-lock.json` regenerated; `npm ls axios` confirms `axios@1.18.1`

## Verification

- `npm run build` - clean
- `npm test` - 56/56 pass (3 suites)
- `npm run lint` - eslint clean (prettier line-ending warnings are the known local CRLF artefact; CI runs on Linux/LF)

## Regression watch (axios 1.18.x behaviour changes)

- Cross-origin redirects now strip caller-set auth/API-key headers
- Malformed `http:`/`https:` URLs (missing `//`) now throw `ERR_INVALID_URL`
- Merged config/header objects are null-prototype
- `AxiosError.toJSON()` now redacts sensitive keys (log output changes)
